### PR TITLE
Making DataAPI a field on Authorization

### DIFF
--- a/docs/heroku_applink/authorization.md
+++ b/docs/heroku_applink/authorization.md
@@ -29,10 +29,9 @@ class should not leak outside of the Authorization class.
 # `Authorization`
 
 ```python
-class Authorization(connection: heroku_applink.connection.Connection, id: str, status: str, org: heroku_applink.authorization.Org, created_at: str, last_modified_at: str, created_by: str, last_modified_by: str)
+class Authorization(connection: heroku_applink.connection.Connection, data_api: heroku_applink.data_api.DataAPI, id: str, status: str, org: heroku_applink.authorization.Org, created_at: str, last_modified_at: str, created_by: str, last_modified_by: str)
 ```
-Authorization information for a Salesforce org with access to a Data API for
-making SOQL queries.
+Authorization(connection: heroku_applink.connection.Connection, data_api: heroku_applink.data_api.DataAPI, id: str, status: str, org: heroku_applink.authorization.Org, created_at: str, last_modified_at: str, created_by: str, last_modified_by: str)
 
 ## Static methods
 
@@ -52,13 +51,24 @@ For a list of exceptions, see:
 ## Instance variables
 
 * `connection: heroku_applink.connection.Connection`
-    The type of the None singleton.
+    Authorization information for a Salesforce org with access to a Data API for
+    making SOQL queries.
 
 * `created_at: str`
     The type of the None singleton.
 
 * `created_by: str`
     The type of the None singleton.
+
+* `data_api: heroku_applink.data_api.DataAPI`
+    An initialized data API client instance for interacting with data in the org.
+    
+    Example usage:
+    
+    ```python
+    authorization = await Authorization.find(developer_name)
+    result = await authorization.data_api.query("SELECT Id, Name FROM Account")
+    ```
 
 * `id: str`
     The type of the None singleton.
@@ -67,27 +77,13 @@ For a list of exceptions, see:
     The type of the None singleton.
 
 * `last_modified_by: str`
-    Example usage:
-    
-    ```python
-    authorization = await Authorization.find(developer_name)
-    data_api = authorization.data_api()
-    result = await data_api.query("SELECT Id, Name FROM Account")
-    ```
+    The type of the None singleton.
 
 * `org: heroku_applink.authorization.Org`
     The type of the None singleton.
 
 * `status: str`
     The type of the None singleton.
-
-## Methods
-
-### `data_api`
-
-```python
-def data_api(self) ‑> heroku_applink.data_api.DataAPI
-```
 
 <!-- python-org.md -->
 # `Org`

--- a/docs/heroku_applink/index.md
+++ b/docs/heroku_applink/index.md
@@ -78,10 +78,9 @@ Classes
 # `Authorization`
 
 ```python
-class Authorization(connection: heroku_applink.connection.Connection, id: str, status: str, org: heroku_applink.authorization.Org, created_at: str, last_modified_at: str, created_by: str, last_modified_by: str)
+class Authorization(connection: heroku_applink.connection.Connection, data_api: heroku_applink.data_api.DataAPI, id: str, status: str, org: heroku_applink.authorization.Org, created_at: str, last_modified_at: str, created_by: str, last_modified_by: str)
 ```
-Authorization information for a Salesforce org with access to a Data API for
-making SOQL queries.
+Authorization(connection: heroku_applink.connection.Connection, data_api: heroku_applink.data_api.DataAPI, id: str, status: str, org: heroku_applink.authorization.Org, created_at: str, last_modified_at: str, created_by: str, last_modified_by: str)
 
 ## Static methods
 
@@ -101,13 +100,24 @@ For a list of exceptions, see:
 ## Instance variables
 
 * `connection: heroku_applink.connection.Connection`
-    The type of the None singleton.
+    Authorization information for a Salesforce org with access to a Data API for
+    making SOQL queries.
 
 * `created_at: str`
     The type of the None singleton.
 
 * `created_by: str`
     The type of the None singleton.
+
+* `data_api: heroku_applink.data_api.DataAPI`
+    An initialized data API client instance for interacting with data in the org.
+    
+    Example usage:
+    
+    ```python
+    authorization = await Authorization.find(developer_name)
+    result = await authorization.data_api.query("SELECT Id, Name FROM Account")
+    ```
 
 * `id: str`
     The type of the None singleton.
@@ -116,27 +126,13 @@ For a list of exceptions, see:
     The type of the None singleton.
 
 * `last_modified_by: str`
-    Example usage:
-    
-    ```python
-    authorization = await Authorization.find(developer_name)
-    data_api = authorization.data_api()
-    result = await data_api.query("SELECT Id, Name FROM Account")
-    ```
+    The type of the None singleton.
 
 * `org: heroku_applink.authorization.Org`
     The type of the None singleton.
 
 * `status: str`
     The type of the None singleton.
-
-## Methods
-
-### `data_api`
-
-```python
-def data_api(self) ‑> heroku_applink.data_api.DataAPI
-```
 
 <!-- python-clientcontext.md -->
 # `ClientContext`

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -55,7 +55,7 @@ async def test_attachment_based_success(monkeypatch):
 
         assert isinstance(authorization, Authorization)
         assert isinstance(authorization.connection, Connection)
-        assert isinstance(authorization.data_api(), DataAPI)
+        assert isinstance(authorization.data_api, DataAPI)
 
         assert authorization is not None
 


### PR DESCRIPTION
# Pull Request

## Summary

Doing this instead of a method call since it should never change. Also cleaned up docs because I forgot that the comments go below the fileds in Python.

Follow up to: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EWtCMYA1/view

---

## What Changed

* `DataAPI` is now a field on `Authorization`.
* Updated docs to correct format.

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

```bash
# Example
pytest
python examples/your_example.py
```