### PR TITLE
fix: add x-app-uuid to headers for auth requests

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -60,6 +60,7 @@ test = [
 Required environment variables:
 - `HEROKU_APPLINK_API_URL`: Your Heroku Applink endpoint URL
 - `HEROKU_APPLINK_TOKEN`: Your authentication token
+- `HEROKU_APP_ID`: The UUID of your Heroku app - see [Heroku Labs: Dyno Metadata](https://devcenter.heroku.com/articles/dyno-metadata)
 
 Optional environment variables:
 - `HEROKU_APPLINK_STAGING_API_URL`: Staging endpoint URL (if using staging environment)

--- a/docs/heroku_applink/authorization.md
+++ b/docs/heroku_applink/authorization.md
@@ -12,7 +12,7 @@ Classes
 # `AuthBundle`
 
 ```python
-class AuthBundle(*, api_url: str, token: str)
+class AuthBundle(*, api_url: str, token: str, app_uuid: str)
 ```
 A bundle of authentication information for the Salesforce Data API. This
 class should not leak outside of the Authorization class.
@@ -20,6 +20,9 @@ class should not leak outside of the Authorization class.
 ## Instance variables
 
 * `api_url: str`
+    
+
+* `app_uuid: str`
     
 
 * `token: str`

--- a/heroku_applink/authorization.py
+++ b/heroku_applink/authorization.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
 from typing import Optional
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
+from yarl import URL
 
 from .config import Config
 from .connection import Connection
@@ -173,7 +174,8 @@ class Authorization:
 
         connection = Connection(config)
         auth_bundle = _resolve_attachment_or_url(attachment_or_url)
-        request_url = urljoin(auth_bundle.api_url, f"authorizations/{developer_name}")
+        request_url = URL(auth_bundle.api_url) / f"authorizations/{developer_name}"
+
         headers = {
             "Authorization": f"Bearer {auth_bundle.token}",
             "Content-Type": "application/json",

--- a/heroku_applink/authorization.py
+++ b/heroku_applink/authorization.py
@@ -26,6 +26,7 @@ class AuthBundle:
     """
     api_url: str
     token: str
+    app_uuid: str
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class UserAuth:
@@ -176,6 +177,7 @@ class Authorization:
         headers = {
             "Authorization": f"Bearer {auth_bundle.token}",
             "Content-Type": "application/json",
+            "X-App-UUID": auth_bundle.app_uuid,
         }
 
         response = await connection.request("GET", request_url, headers=headers)
@@ -251,6 +253,10 @@ def _resolve_addon_config_by_attachment_or_color(attachment_or_color: str) -> Au
 
     api_url = os.getenv(f"{key}_API_URL")
     token   = os.getenv(f"{key}_TOKEN")
+    app_uuid = os.getenv("HEROKU_APP_ID")
+
+    if not app_uuid:
+        raise EnvironmentError("HEROKU_APP_ID is not set")
 
     if not api_url or not token:
         # fallback: color under the main addon prefix
@@ -264,7 +270,7 @@ def _resolve_addon_config_by_attachment_or_color(attachment_or_color: str) -> Au
             f"{addon_prefix}_{key}_API_URL / {addon_prefix}_{key}_TOKEN"
         )
 
-    return AuthBundle(api_url=api_url, token=token)
+    return AuthBundle(api_url=api_url, token=token, app_uuid=app_uuid)
 
 @lru_cache(maxsize=None)
 def _resolve_addon_config_by_url(url: str) -> AuthBundle:
@@ -272,6 +278,11 @@ def _resolve_addon_config_by_url(url: str) -> AuthBundle:
     Match an env var ending in _API_URL to the given URL, then
     pull the corresponding _TOKEN.
     """
+    app_uuid = os.getenv("HEROKU_APP_ID")
+
+    if not app_uuid:
+        raise EnvironmentError("HEROKU_APP_ID is not set")
+
     for var, val in os.environ.items():
         if var.endswith("_API_URL") and val.lower() == url.lower():
             prefix = var[: -len("_API_URL")]
@@ -280,6 +291,6 @@ def _resolve_addon_config_by_url(url: str) -> AuthBundle:
             if not token:
                 raise EnvironmentError(f"Missing token for API URL: {url}")
 
-            return AuthBundle(api_url=val, token=token)
+            return AuthBundle(api_url=val, token=token, app_uuid=app_uuid)
 
     raise EnvironmentError(f"Heroku Applink config not found for API URL: {url}")

--- a/heroku_applink/config.py
+++ b/heroku_applink/config.py
@@ -7,6 +7,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 
 from dataclasses import dataclass
 
+__version__ = "0.1.0"
 
 @dataclass
 class Config:
@@ -34,6 +35,11 @@ class Config:
     socket_read: float|None = None
     """
     Timeout for reading from the Salesforce Data API.
+    """
+
+    user_agent: str = f"heroku-applink-python-sdk/{__version__}"
+    """
+    User agent for the Salesforce Data API.
     """
 
     @classmethod

--- a/heroku_applink/connection.py
+++ b/heroku_applink/connection.py
@@ -37,7 +37,7 @@ class Connection:
             timeout = aiohttp.ClientTimeout(total=timeout)
 
         default_headers = {
-            "User-Agent": "heroku-applink-python-sdk/0.1.0",
+            "User-Agent": self._config.user_agent,
         }
 
         response = self._client().request(

--- a/heroku_applink/connection.py
+++ b/heroku_applink/connection.py
@@ -36,11 +36,15 @@ class Connection:
         if timeout is not None:
             timeout = aiohttp.ClientTimeout(total=timeout)
 
+        default_headers = {
+            "User-Agent": "heroku-applink-python-sdk/0.1.0",
+        }
+
         response = self._client().request(
             method,
             url,
             params=params,
-            headers=headers,
+            headers=default_headers | (headers or {}),
             data=data,
             timeout=timeout
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.11.12",
-    "orjson>=3.10.15"
+    "orjson>=3.10.15",
+    "yarl>=1.20.0",
 ]
 
 [dependency-groups]

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -68,6 +68,10 @@ def monkeypatch_app_id(monkeypatch):
 
 APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b02a-c55f94d25700"
 
+@pytest.fixture
+def monkeypatch_app_id(monkeypatch):
+    monkeypatch.setenv("HEROKU_APP_ID", "f208caa9-3d49-4660-a2cf-80cd8dde7492")
+
 def assert_authorization_is_valid(authorization: Authorization):
     assert isinstance(authorization, Authorization)
     assert isinstance(authorization.connection, Connection)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -68,10 +68,6 @@ def monkeypatch_app_id(monkeypatch):
 
 APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b02a-c55f94d25700"
 
-@pytest.fixture
-def monkeypatch_app_id(monkeypatch):
-    monkeypatch.setenv("HEROKU_APP_ID", "f208caa9-3d49-4660-a2cf-80cd8dde7492")
-
 def assert_authorization_is_valid(authorization: Authorization):
     assert isinstance(authorization, Authorization)
     assert isinstance(authorization.connection, Connection)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -74,6 +74,10 @@ def monkeypatch_app_id(monkeypatch):
 
 APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b02a-c55f94d25700"
 
+@pytest.fixture
+def monkeypatch_app_id(monkeypatch):
+    monkeypatch.setenv("HEROKU_APP_ID", "f208caa9-3d49-4660-a2cf-80cd8dde7492")
+
 def assert_authorization_is_valid(authorization: Authorization):
     assert isinstance(authorization, Authorization)
     assert isinstance(authorization.connection, Connection)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -68,6 +68,10 @@ def monkeypatch_app_id(monkeypatch):
 
 APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b02a-c55f94d25700"
 
+@pytest.fixture
+def monkeypatch_app_id(monkeypatch):
+    monkeypatch.setenv("HEROKU_APP_ID", "f208caa9-3d49-4660-a2cf-80cd8dde7492")
+
 def assert_authorization_is_valid(authorization: Authorization):
     assert isinstance(authorization, Authorization)
     assert isinstance(authorization.connection, Connection)
@@ -92,7 +96,7 @@ def assert_authorization_is_valid(authorization: Authorization):
     assert authorization.org.user_auth.access_token is not None
 
 @pytest.mark.asyncio
-async def test_find_authorization(monkeypatch):
+async def test_find_authorization(monkeypatch, monkeypatch_app_id):
     developer_name = "TESTING_APPLINK_AUTHS"
 
     monkeypatch.setenv("HEROKU_APPLINK_STAGING_API_URL", APPLINK_URL)
@@ -111,7 +115,7 @@ async def test_find_authorization(monkeypatch):
         assert_authorization_is_valid(authorization)
 
 @pytest.mark.asyncio
-async def test_attachment_based_success(monkeypatch):
+async def test_attachment_based_success(monkeypatch, monkeypatch_app_id):
     developer_name = "devName"
 
     # Call without trailing slash base, ensure rstrip

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -72,6 +72,8 @@ APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b
 def monkeypatch_app_id(monkeypatch):
     monkeypatch.setenv("HEROKU_APP_ID", "f208caa9-3d49-4660-a2cf-80cd8dde7492")
 
+APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b02a-c55f94d25700"
+
 def assert_authorization_is_valid(authorization: Authorization):
     assert isinstance(authorization, Authorization)
     assert isinstance(authorization.connection, Connection)


### PR DESCRIPTION



# Pull Request

## Summary

The AppLink control plane requires this header to be present as part of validations, so lets ensure it is present.

Additionally, lets set a valid User-Agent header to indicate this is from the SDK.

Ref: W-18723611

Fixes #

---

## What Changed

- Update `AuthBundle` dataclass with `app_uuid` field.
- Populate `app_uuid` from environment.
- Pass in `app_uuid` as part of auth requests via `X-App-UUID` header.
- Set `User-Agent` header to something to indicate its from this SDK.

---

## Checklist


- [X] I’ve added or updated unit tests where necessary
- [X] I’ve added or updated documentation
- [X] I've run `pdoc3` to generate the documentation
- [ ] I’ve manually tested the functionality in this PR
- [X] This pull request is ready for review

---

## Testing

Just through unit tests for now.
