### PR TITLE
Fixing a bug that caused URL paths to be excluded

### DIFF
--- a/heroku_applink/authorization.py
+++ b/heroku_applink/authorization.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
 from typing import Optional
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
+from yarl import URL
 
 from .config import Config
 from .connection import Connection
@@ -172,7 +173,8 @@ class Authorization:
 
         connection = Connection(config)
         auth_bundle = _resolve_attachment_or_url(attachment_or_url)
-        request_url = urljoin(auth_bundle.api_url, f"authorizations/{developer_name}")
+        request_url = URL(auth_bundle.api_url) / f"authorizations/{developer_name}"
+
         headers = {
             "Authorization": f"Bearer {auth_bundle.token}",
             "Content-Type": "application/json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.11.12",
-    "orjson>=3.10.15"
+    "orjson>=3.10.15",
+    "yarl>=1.20.0",
 ]
 
 [dependency-groups]

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -86,6 +86,27 @@ def assert_authorization_is_valid(authorization: Authorization):
     assert authorization.org.user_auth.access_token is not None
 
 @pytest.mark.asyncio
+async def test_find_authorization(monkeypatch):
+    monkeypatch.setenv("HEROKU_APPLINK_API_URL", "https://applink.staging.herokudev.com/addons/1234567890")
+    monkeypatch.setenv("HEROKU_APPLINK_STAGING_API_URL", "https://applink.staging.herokudev.com/addons/1234567890")
+    monkeypatch.setenv("HEROKU_APPLINK_STAGING_TOKEN", "1234567890")
+    monkeypatch.setenv("HEROKU_APPLINK_TOKEN", "1234567890")
+
+    developer_name = "TESTING_APPLINK_AUTHS"
+
+    with aioresponses() as m:
+        m.get(
+            f"https://applink.staging.herokudev.com/addons/1234567890/authorizations/{developer_name}",
+            status=200,
+            payload=VALID_RESPONSE
+        )
+
+        authorization = await Authorization.find(developer_name, "HEROKU_APPLINK_STAGING")
+
+        assert_authorization_is_valid(authorization)
+
+
+@pytest.mark.asyncio
 async def test_attachment_based_success(monkeypatch):
     developer_name = "devName"
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -62,6 +62,8 @@ VALID_RESPONSE_NO_REDIRECT_URI: Dict[str, Any] = {
     "last_modified_by": "foo@heroku.com",
 }
 
+APPLINK_URL = "https://applink.staging.herokudev.com/addons/97a3472c-a724-4bb5-b02a-c55f94d25700"
+
 def assert_authorization_is_valid(authorization: Authorization):
     assert isinstance(authorization, Authorization)
     assert isinstance(authorization.connection, Connection)
@@ -87,16 +89,15 @@ def assert_authorization_is_valid(authorization: Authorization):
 
 @pytest.mark.asyncio
 async def test_find_authorization(monkeypatch):
-    applink_url = "https://applink.staging.herokudev.com/addons/1234567890"
     developer_name = "TESTING_APPLINK_AUTHS"
 
-    monkeypatch.setenv("HEROKU_APPLINK_STAGING_API_URL", applink_url)
+    monkeypatch.setenv("HEROKU_APPLINK_STAGING_API_URL", APPLINK_URL)
     monkeypatch.setenv("HEROKU_APPLINK_STAGING_TOKEN", "1234567890")
     monkeypatch.setenv("HEROKU_APP_ID", "1234567890")
 
     with aioresponses() as m:
         m.get(
-            f"{applink_url}/authorizations/{developer_name}",
+            f"{APPLINK_URL}/authorizations/{developer_name}",
             status=200,
             payload=VALID_RESPONSE
         )

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -87,16 +87,16 @@ def assert_authorization_is_valid(authorization: Authorization):
 
 @pytest.mark.asyncio
 async def test_find_authorization(monkeypatch):
-    monkeypatch.setenv("HEROKU_APPLINK_API_URL", "https://applink.staging.herokudev.com/addons/1234567890")
-    monkeypatch.setenv("HEROKU_APPLINK_STAGING_API_URL", "https://applink.staging.herokudev.com/addons/1234567890")
-    monkeypatch.setenv("HEROKU_APPLINK_STAGING_TOKEN", "1234567890")
-    monkeypatch.setenv("HEROKU_APPLINK_TOKEN", "1234567890")
-
+    applink_url = "https://applink.staging.herokudev.com/addons/1234567890"
     developer_name = "TESTING_APPLINK_AUTHS"
+
+    monkeypatch.setenv("HEROKU_APPLINK_STAGING_API_URL", applink_url)
+    monkeypatch.setenv("HEROKU_APPLINK_STAGING_TOKEN", "1234567890")
+    monkeypatch.setenv("HEROKU_APP_ID", "1234567890")
 
     with aioresponses() as m:
         m.get(
-            f"https://applink.staging.herokudev.com/addons/1234567890/authorizations/{developer_name}",
+            f"{applink_url}/authorizations/{developer_name}",
             status=200,
             payload=VALID_RESPONSE
         )

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -106,7 +106,6 @@ async def test_find_authorization(monkeypatch):
 
         assert_authorization_is_valid(authorization)
 
-
 @pytest.mark.asyncio
 async def test_attachment_based_success(monkeypatch):
     developer_name = "devName"


### PR DESCRIPTION
# Pull Request

## Summary

This is an issue with how urljoin worked in that if a URL contained a path in the first parameter it would be excluded when the join took place. Our test coverage didn't check for this kind of condition initially.

Fixes #W-18725788

---

## What Changed

Using `yarl` to handle URI parsing.

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->

```bash
# Example
pytest
python examples/your_example.py
