### PR TITLE
Include X-Request-Id header in all outbound requests

### DIFF
--- a/heroku_applink/__init__.py
+++ b/heroku_applink/__init__.py
@@ -5,6 +5,8 @@ SPDX-License-Identifier: BSD-3-Clause
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 """
 
+from contextvars import ContextVar
+
 from .authorization import Authorization
 from .config import Config
 from .context import ClientContext
@@ -14,7 +16,10 @@ from .data_api.unit_of_work import UnitOfWork
 from .middleware import IntegrationWsgiMiddleware, IntegrationAsgiMiddleware
 from .exceptions import ClientError, UnexpectedRestApiResponsePayload
 from .connection import Connection
-from .middleware import client_context
+
+# ContextVars for request-scoped data
+client_context: ContextVar[ClientContext] = ContextVar("client_context")
+request_id: ContextVar[str] = ContextVar("request_id")
 
 def get_client_context() -> ClientContext:
     """
@@ -74,6 +79,7 @@ __all__ = [
     "Config",
     "Connection",
     "client_context",
+    "request_id",
     "ClientContext",
     "QueriedRecord",
     "Record",

--- a/heroku_applink/connection.py
+++ b/heroku_applink/connection.py
@@ -53,7 +53,9 @@ class Connection:
             "X-Request-Id": request_id.get(str(uuid.uuid4())),
         }
 
-        headers = {**default_headers, **(headers or {})}
+        # Start with custom headers, then override with default headers
+        # This ensures our default headers (User-Agent, X-Request-Id) always take precedence
+        headers = {**(headers or {}), **default_headers}
 
         response = self._client().request(
             method,

--- a/heroku_applink/connection.py
+++ b/heroku_applink/connection.py
@@ -7,6 +7,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 
 import aiohttp
 import asyncio
+import uuid
 
 from .config import Config
 
@@ -37,14 +38,21 @@ class Connection:
             timeout = aiohttp.ClientTimeout(total=timeout)
 
         default_headers = {
+            # Always include the user-agent header in all outbound requests.
+            # This is so we can track SDK versions across all of our customers.
             "User-Agent": self._config.user_agent(),
+            # Always include a request-id header in all outbound requests.
+            # This will be helpful for debugging and tracking requests.
+            "X-Request-Id": str(uuid.uuid4()),
         }
+
+        headers = {**default_headers, **(headers or {})}
 
         response = self._client().request(
             method,
             url,
             params=params,
-            headers=default_headers | (headers or {}),
+            headers=headers,
             data=data,
             timeout=timeout
         )

--- a/heroku_applink/connection.py
+++ b/heroku_applink/connection.py
@@ -34,6 +34,10 @@ class Connection:
 
         If a timeout is provided, it will be used to set the timeout for the request.
         """
+
+        # Import here to avoid circular imports
+        from . import request_id
+
         if timeout is not None:
             timeout = aiohttp.ClientTimeout(total=timeout)
 
@@ -43,7 +47,10 @@ class Connection:
             "User-Agent": self._config.user_agent(),
             # Always include a request-id header in all outbound requests.
             # This will be helpful for debugging and tracking requests.
-            "X-Request-Id": str(uuid.uuid4()),
+            #
+            # Using `request_id` we can get any request-id set by the middleware.
+            # If no request-id is set, we generate a new one.
+            "X-Request-Id": request_id.get(str(uuid.uuid4())),
         }
 
         headers = {**default_headers, **(headers or {})}

--- a/tests/test_asgi_api.py
+++ b/tests/test_asgi_api.py
@@ -16,7 +16,7 @@ async def root():
 
 @app.get("/client-context")
 async def client_context():
-    data_api = sdk.client_context.get().data_api
+    data_api = sdk.get_client_context().data_api
 
     return {"data_api_populated": data_api is not None}
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -256,7 +256,7 @@ async def test_connection_user_agent_header_always_set(connection):
 
         request_kwargs = m.requests[('GET', URL('https://example.com'))][0].kwargs
         headers = request_kwargs['headers']
-        assert headers['User-Agent'] == connection._config.user_agent
+        assert headers['User-Agent'] == connection._config.user_agent()
 
 @pytest.mark.asyncio
 async def test_connection_default_headers_with_contextvar_reset(connection):

--- a/tests/test_wsgi_api.py
+++ b/tests/test_wsgi_api.py
@@ -15,7 +15,7 @@ def index():
 
 @app.route("/client-context")
 def client_context():
-    data_api = sdk.client_context.get().data_api
+    data_api = sdk.get_client_context().data_api
 
     return jsonify({"data_api_populated": data_api is not None})
 


### PR DESCRIPTION
# Pull Request

## Summary

Populates the `X-Request-Id` header in all outbound requests.

Fixes #W-18740276

---

## What Changed

`X-Request-Id` header is being populated in all outbound requests.

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->

```bash
# Example
pytest
python examples/your_example.py
