### PR TITLE
Test on Multiple OSes and specify a version of Python when testing

### DIFF
--- a/.github/workflows/test-lint-build.yml
+++ b/.github/workflows/test-lint-build.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
 
     steps:
@@ -44,12 +45,19 @@ jobs:
 
       - name: Install ruff
         run: uv pip install ruff
-        
+
       - name: Run linting
         run: uv run ruff check .
 
+      - name: Set tox environment name
+        id: tox-env
+        run: |
+          TOX_ENV="py$(echo '${{ matrix.python-version }}' | sed 's/\.//')"
+          echo "name=$TOX_ENV" >> $GITHUB_OUTPUT
+          echo "Using tox environment: $TOX_ENV"
+
       - name: Run tests
-        run: uv run tox
+        run: uv run tox -e ${{ steps.tox-env.outputs.name }} -v
 
       - name: Build package
         run: uv build


### PR DESCRIPTION
# Pull Request

## Summary

Test on Linux/Windows/macOS and make sure each build only tests a specific version of Python.

Part of #W-18740836

---

## What Changed

* Added multiple OSes to the build matrix
* Setup tox to only test the specific version of Python in the matrix.

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

Take a look at the GitHub actions builts and make sure they are all passing.
