### PR TITLE
building instead of downloading artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,29 +33,35 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for Trusted Publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Get latest build workflow run
-        id: get_workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Get the latest tag
+        id: get_tag
         run: |
-          # Get the most recent successful build workflow run for this commit
-          RUN_ID=$(gh run list --workflow "test-lint-build.yml" --branch main --json databaseId,conclusion,headSha --jq ".[] | select(.headSha == \"${{ github.sha }}\" and .conclusion == \"success\") | .databaseId" | head -n 1)
-          
-          if [ -z "$RUN_ID" ]; then
-            echo "No successful build found for commit ${{ github.sha }}"
-            exit 1
-          fi
-          
-          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
-          echo "Found build workflow run: $RUN_ID"
+          TAG=$(git describe --tags --abbrev=0)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Using tag: $TAG"
 
-      - name: Download build artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Checkout the tagged version
         run: |
-          mkdir -p dist
-          gh run download ${{ steps.get_workflow.outputs.run_id }} --name release-artifacts-main --dir dist/
+          git checkout ${{ steps.get_tag.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Build package
+        run: uv build
 
       - name: Release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -24,12 +24,21 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download artifact using GitHub CLI
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p dist
-          gh run download ${{ github.event.workflow_run.id }} --name release-artifacts-main --dir dist/
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Build package
+        run: uv build
 
       - name: Extract version from branch name
         id: version

--- a/.github/workflows/test-lint-build.yml
+++ b/.github/workflows/test-lint-build.yml
@@ -62,10 +62,3 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Upload artifacts for release
-        if: ${{ matrix.python-version == steps.pyproject-version.outputs.version && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'release-v') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.ref_name }}
-          path: dist/
-          retention-days: 90


### PR DESCRIPTION
# Pull Request

## Summary

<!--
Briefly explain the purpose of this PR.
What functionality or bug does it address?
Reference any related issues with "Fixes #123" or "Closes #456".
-->
---
The release pipeline failed because 
```
error fetching artifacts: HTTP 403: Although you appear to have the correct authorization credentials, the `heroku` organization has an IP allow list enabled, and your IP address is not permitted to access this resource. (https://api.github.com/repos/heroku/heroku-applink-python/actions/runs/15765837302/artifacts?per_page=100)
```

This PR makes a change so that we build the package from the release tag instead of attempting to download a release artifact for tagging and building. 
## What Changed

<!--
Describe the key changes in this PR.
If it's a bug fix, describe what was broken and how it's fixed.
If it's a feature, explain how it works and any limitations.
-->

---
bug fix
## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->

```bash
# Example
pytest
python examples/your_example.py
