### PR TITLE
Don't use `raise_for_status` by default

### DIFF
--- a/heroku_applink/authorization.py
+++ b/heroku_applink/authorization.py
@@ -183,6 +183,7 @@ class Authorization:
         }
 
         response = await connection.request("GET", request_url, headers=headers)
+        response.raise_for_status()
         payload = await response.json()
 
         return Authorization._build_authorization(connection, payload)

--- a/heroku_applink/connection.py
+++ b/heroku_applink/connection.py
@@ -124,7 +124,6 @@ class Connection:
                 # Disable cookie storage using `DummyCookieJar`, given that we
                 # don't need cookie support.
                 cookie_jar=aiohttp.DummyCookieJar(),
-                raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(
                     total=self._config.request_timeout,
                     connect=self._config.connect_timeout,

--- a/heroku_applink/data_api/exceptions.py
+++ b/heroku_applink/data_api/exceptions.py
@@ -7,7 +7,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 
 from dataclasses import dataclass
 
-# The order in `__all__` is the in which pdoc3 will display the classes in the docs.
+# The order in `__all__` is the order in which pdoc3 will display the classes in the docs.
 __all__ = [
     "DataApiError",
     "SalesforceRestApiError",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -85,10 +85,9 @@ async def test_connection_request_error(connection):
             payload={'error': 'Internal Server Error'}
         )
 
-        with pytest.raises(aiohttp.ClientResponseError) as exc_info:
-            await connection.request("GET", "https://example.com")
+        response = await connection.request("GET", "https://example.com")
 
-        assert exc_info.value.status == 500
+        assert response.status == 500
 
 @pytest.mark.asyncio
 async def test_connection_close(connection):


### PR DESCRIPTION
# Pull Request

## Summary

<!--
Briefly explain the purpose of this PR.
What functionality or bug does it address?
Reference any related issues with "Fixes #123" or "Closes #456".
-->

The use of `raise_for_status` in our client session was preventing us from returning detailed information about Salesforce errors.

For example, when we got authorization errors previously, we were raising an `aiohttp.ClientResponseError` with `status=401` and `message="Unauthorized"`.

---

## What Changed

The new behavior is that we no longer raise an `aiohttp.ClientResponseError`. In the above example, we raise a `SalesforceRestApiError` with `message="Session expired or invalid"` and `error_code="INVALID_SESSION_ID"`.

You can inspect the exception and add handling like this:
```
    query = "SELECT Id, Name FROM Account"
    try:
        result = await authorization.data_api.query(query)
    except SalesforceRestApiError as e:
        for error in e.api_errors:
            print(f"Error message: {error.message}")
            print(f"Error code: {error.error_code}")
            if error.fields:
                print(f"Fields: {error.fields.join(", ")}")
```

<!--
Describe the key changes in this PR.
If it's a bug fix, describe what was broken and how it's fixed.
If it's a feature, explain how it works and any limitations.
-->

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->
* I created a Flask-based sample app and used the `IntegrationWsgiMiddleware` as described in this repo's README and deployed it to Heroku. 
* I set up AppLink, created a connection to my Salesforce org, set up an authorization, and published an API spec. 
* I made my Python SDK changes in a fork originally and added it as a dependency using `uv add git+https://github.com/<user>/<repo>`
* To force the `INVALID_SESSION_ID` error, I manually invalidated non-UI sessions using the Salesforce session management admin page.
* To invoke my API, I ran this Apex code anonymously:
```
herokuapplink.MyAPI h = new herokuapplink.MyAPI();
h.GetAccounts();
```