### PR TITLE
refactor: add GPG key to enable signed tags

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -47,10 +47,14 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
-      - name: Configure Git
+      - name: Setup GPG and configure Git
         run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@github.com"
+          git config --global user.signingkey ${{ secrets.GPG_KEY_ID }}
+          git config --global commit.gpgsign true
+          git config --global tag.gpgsign true
 
       - name: Create and push Github tag
         run: |


### PR DESCRIPTION
# Pull Request
This PR adds a step in the git tag action to add a GPG key, required when signing git tags. We want to use signed tags instead of annotated tags for security and compliance requirements. 

## Summary

<!--
Briefly explain the purpose of this PR.
What functionality or bug does it address?
Reference any related issues with "Fixes #123" or "Closes #456".
-->
Bug in the release process, 
```
error: gpg failed to sign the data:
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: skipped "GitHub Actions <github-actions@github.com>": No secret key
[GNUPG:] INV_SGNR 9 GitHub Actions <github-actions@github.com>
[GNUPG:] FAILURE sign 17
gpg: signing failed: No secret key

error: unable to sign the tag
The tag message has been left in .git/TAG_EDITMSG
Error: Process completed with exit code 128.
```
Fixes #

---
bug in the release process
## What Changed

<!--
Describe the key changes in this PR.
If it's a bug fix, describe what was broken and how it's fixed.
If it's a feature, explain how it works and any limitations.
-->

---

## Checklist


- [n/a] I’ve added or updated unit tests where necessary
- [n/a] I’ve added or updated documentation
- [n/a] I've run `pdoc3` to generate the documentation
- [n/a] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->

```bash
# Example
pytest
python examples/your_example.py
