### PR TITLE
refactor: attempt to add gpg key with passphrase too

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -47,9 +47,12 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
-      - name: Setup GPG and configure Git
+      - name: Set up GPG
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --import <(echo "${{ secrets.GPG_PRIVATE_KEY }}")
+
+      - name: Configure Git
+        run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@github.com"
           git config --global user.signingkey ${{ secrets.GPG_KEY_ID }}
@@ -80,3 +83,8 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
           generate_release_notes: true
+
+      - name: Cleanup GPG keys
+        run: |
+          gpg --delete-secret-keys --batch --yes "${{ secrets.GPG_KEY_ID }}"
+          gpg --delete-keys --batch --yes "${{ secrets.GPG_KEY_ID }}"


### PR DESCRIPTION
# Pull Request

## Summary

<!--
Briefly explain the purpose of this PR.
What functionality or bug does it address?
Reference any related issues with "Fixes #123" or "Closes #456".
-->

---
Release bug, fails with
```
error: gpg failed to sign the data:
[GNUPG:] KEY_CONSIDERED 8D871E8F9DF06B530D2B5948*** 2
[GNUPG:] BEGIN_SIGNING H10
[GNUPG:] PINENTRY_LAUNCHED 2200 curses 1.2.1 - - - - 1001/118 -
gpg: signing failed: Inappropriate ioctl for device
[GNUPG:] FAILURE sign 83918950
gpg: signing failed: Inappropriate ioctl for device

error: unable to sign the tag
The tag message has been left in .git/TAG_EDITMSG
```
Took example from: https://github.com/heroku/heroku-applink-service-mesh/blob/bc15f7d46e092f0b5d533d109e9108da95793965/.github/workflows/build-and-sign.yml#L67-L70

for GPG setup and importing the key with the passphrase
## What Changed

<!--
Describe the key changes in this PR.
If it's a bug fix, describe what was broken and how it's fixed.
If it's a feature, explain how it works and any limitations.
-->

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->

```bash
# Example
pytest
python examples/your_example.py
