### PR TITLE
Make access_token optional 

### DIFF
--- a/docs/heroku_applink/context.md
+++ b/docs/heroku_applink/context.md
@@ -12,7 +12,7 @@ Classes
 # `ClientContext`
 
 ```python
-class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str, api_version: str, namespace: str | None = None)
+class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str | None, api_version: str, namespace: str | None = None)
 ```
 Information about the Salesforce org that made the request.
 
@@ -24,7 +24,7 @@ def from_header(header: str, connection: heroku_applink.connection.Connection)
 
 ## Instance variables
 
-* `access_token: str`
+* `access_token: str | None`
     Valid access token for the current context org/user.
 
 * `api_version: str`

--- a/docs/heroku_applink/context.md
+++ b/docs/heroku_applink/context.md
@@ -12,7 +12,7 @@ Classes
 # `ClientContext`
 
 ```python
-class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str | None, api_version: str, namespace: str | None = None)
+class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str | None, api_version: str, namespace: str | None = None)
 ```
 Information about the Salesforce org that made the request.
 
@@ -24,7 +24,7 @@ def from_header(header: str, connection: heroku_applink.connection.Connection)
 
 ## Instance variables
 
-* `access_token: str | None`
+* `access_token: str | None`
     Valid access token for the current context org/user.
 
 * `api_version: str`

--- a/docs/heroku_applink/data_api/index.md
+++ b/docs/heroku_applink/data_api/index.md
@@ -20,7 +20,7 @@ Classes
 # `DataAPI`
 
 ```python
-class DataAPI(*, org_domain_url: str, api_version: str, access_token: str, connection: heroku_applink.connection.Connection)
+class DataAPI(*, org_domain_url: str, api_version: str, access_token: str | None, connection: heroku_applink.connection.Connection)
 ```
 Data API client to interact with data in a Salesforce org.
 

--- a/docs/heroku_applink/data_api/index.md
+++ b/docs/heroku_applink/data_api/index.md
@@ -20,7 +20,7 @@ Classes
 # `DataAPI`
 
 ```python
-class DataAPI(*, org_domain_url: str, api_version: str, access_token: str | None, connection: heroku_applink.connection.Connection)
+class DataAPI(*, org_domain_url: str, api_version: str, access_token: str | None, connection: heroku_applink.connection.Connection)
 ```
 Data API client to interact with data in a Salesforce org.
 

--- a/docs/heroku_applink/index.md
+++ b/docs/heroku_applink/index.md
@@ -184,7 +184,7 @@ For a list of exceptions, see:
 # `ClientContext`
 
 ```python
-class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str, api_version: str, namespace: str | None = None)
+class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str | None, api_version: str, namespace: str | None = None)
 ```
 Information about the Salesforce org that made the request.
 
@@ -196,7 +196,7 @@ def from_header(header: str, connection: heroku_applink.connection.Connection)
 
 ## Instance variables
 
-* `access_token: str`
+* `access_token: str | None`
     Valid access token for the current context org/user.
 
 * `api_version: str`

--- a/docs/heroku_applink/index.md
+++ b/docs/heroku_applink/index.md
@@ -184,7 +184,7 @@ For a list of exceptions, see:
 # `ClientContext`
 
 ```python
-class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str | None, api_version: str, namespace: str | None = None)
+class ClientContext(*, org: heroku_applink.context.Org, data_api: heroku_applink.data_api.DataAPI, request_id: str, access_token: str | None, api_version: str, namespace: str | None = None)
 ```
 Information about the Salesforce org that made the request.
 
@@ -196,7 +196,7 @@ def from_header(header: str, connection: heroku_applink.connection.Connection)
 
 ## Instance variables
 
-* `access_token: str | None`
+* `access_token: str | None`
     Valid access token for the current context org/user.
 
 * `api_version: str`

--- a/heroku_applink/context.py
+++ b/heroku_applink/context.py
@@ -122,7 +122,7 @@ def get_client_context() -> ClientContext:
 
     ```python
     import heroku_applink as sdk
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI
 
     app = FastAPI()
     app.add_middleware(sdk.IntegrationAsgiMiddleware, config=sdk.Config(request_timeout=5))

--- a/heroku_applink/context.py
+++ b/heroku_applink/context.py
@@ -130,8 +130,6 @@ def get_client_context() -> ClientContext:
     @app.get("/accounts")
     async def get_accounts():
         context = sdk.get_client_context()
-        if context.data_api is None:
-            raise HTTPException(status_code=401, detail="Data API not available")
 
         query = "SELECT Id, Name FROM Account"
         result = await context.data_api.query(query)

--- a/heroku_applink/context.py
+++ b/heroku_applink/context.py
@@ -69,7 +69,7 @@ class ClientContext:
     """An initialized data API client instance for interacting with data in the org."""
     request_id: str
     """Request ID from the Salesforce org."""
-    access_token: str
+    access_token: str | None
     """Valid access token for the current context org/user."""
     api_version: str
     """API version of the Salesforce component that made the request."""
@@ -91,13 +91,13 @@ class ClientContext:
                 ),
             ),
             request_id=data["requestId"],
-            access_token=data["accessToken"],
+            access_token=data.get("accessToken"),
             api_version=data["apiVersion"],
             namespace=data.get("namespace"),  # Use get() to handle None case
             data_api=DataAPI(
                 org_domain_url=data["orgDomainUrl"],
                 api_version=data["apiVersion"],
-                access_token=data["accessToken"],
+                access_token=data.get("accessToken"),
                 connection=connection,
             ),
         )

--- a/heroku_applink/context.py
+++ b/heroku_applink/context.py
@@ -65,8 +65,8 @@ class ClientContext:
 
     org: Org
     """Information about the Salesforce org and the user that made the request."""
-    data_api: DataAPI
-    """An initialized data API client instance for interacting with data in the org."""
+    data_api: DataAPI | None
+    """An initialized data API client instance for interacting with data in the org. None if no access token is available."""
     request_id: str
     """Request ID from the Salesforce org."""
     access_token: str | None
@@ -81,6 +81,19 @@ class ClientContext:
         decoded = base64.b64decode(header)
         data = json.loads(decoded)
 
+        access_token = data.get("accessToken")
+        
+        # Set data_api only if access token is available
+        if access_token is None:
+            data_api = None
+        else:
+            data_api = DataAPI(
+                org_domain_url=data["orgDomainUrl"],
+                api_version=data["apiVersion"],
+                access_token=access_token,
+                connection=connection,
+            )
+        
         return cls(
             org=Org(
                 id=data["orgId"],
@@ -91,15 +104,10 @@ class ClientContext:
                 ),
             ),
             request_id=data["requestId"],
-            access_token=data.get("accessToken"),
+            access_token=access_token,
             api_version=data["apiVersion"],
             namespace=data.get("namespace"),  # Use get() to handle None case
-            data_api=DataAPI(
-                org_domain_url=data["orgDomainUrl"],
-                api_version=data["apiVersion"],
-                access_token=data.get("accessToken"),
-                connection=connection,
-            ),
+            data_api=data_api,
         )
 
 # ContextVars for request-scoped data
@@ -114,7 +122,7 @@ def get_client_context() -> ClientContext:
 
     ```python
     import heroku_applink as sdk
-    from fastapi import FastAPI
+    from fastapi import FastAPI, HTTPException
 
     app = FastAPI()
     app.add_middleware(sdk.IntegrationAsgiMiddleware, config=sdk.Config(request_timeout=5))
@@ -122,6 +130,8 @@ def get_client_context() -> ClientContext:
     @app.get("/accounts")
     async def get_accounts():
         context = sdk.get_client_context()
+        if context.data_api is None:
+            raise HTTPException(status_code=401, detail="Data API not available")
 
         query = "SELECT Id, Name FROM Account"
         result = await context.data_api.query(query)

--- a/heroku_applink/data_api/__init__.py
+++ b/heroku_applink/data_api/__init__.py
@@ -45,7 +45,7 @@ class DataAPI:
         *,
         org_domain_url: str,
         api_version: str,
-        access_token: str,
+        access_token: str | None,
         connection: Connection,
     ) -> None:
         self._api_version = api_version
@@ -251,9 +251,10 @@ class DataAPI:
         return await response.read()
 
     def _default_headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self.access_token}",
-        }
+        headers = {}
+        if self.access_token is not None:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+        return headers
 
 
 def _json_serialize(data: Any) -> BytesPayload:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -74,6 +74,8 @@ def test_client_context_from_header():
     assert ctx.access_token == "access-token-xyz"
     assert ctx.api_version == "v57.0"
     assert ctx.namespace == "ns"
+    assert ctx.data_api is not None  # DataAPI should be created when access token is present
+    assert ctx.data_api.access_token == "access-token-xyz"  # DataAPI should have the access token
 
 def test_client_context_from_header_invalid():
     # Provide bad Base64 encoded string
@@ -127,4 +129,4 @@ def test_client_context_from_header_missing_access_token():
     assert ctx.api_version == "v57.0"
     assert ctx.namespace == "ns"
     assert ctx.access_token is None  # Should be None when missing
-    assert ctx.data_api.access_token is None  # DataAPI should also have None access_token
+    assert ctx.data_api is None  # DataAPI should not be created when no access token

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -103,3 +103,28 @@ def test_client_context_from_header_with_null_namespace():
     assert ctx.access_token == "access-token-xyz"
     assert ctx.api_version == "v57.0"
     assert ctx.namespace is None
+
+def test_client_context_from_header_missing_access_token():
+    payload = {
+        "orgId": "00DJS0000000123ABC",
+        "orgDomainUrl": "https://example-domain.my.salesforce.com",
+        "userContext": {
+            "userId": "005JS000000H123",
+            "username": "user@example.tld",
+        },
+        "requestId": "req-456",
+        # Note: accessToken is intentionally missing
+        "apiVersion": "v57.0",
+        "namespace": "ns",
+    }
+    encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+    connection = Connection(Config.default())
+    ctx = ClientContext.from_header(encoded, connection)
+
+    assert ctx.org.id == "00DJS0000000123ABC"
+    assert ctx.org.user.username == "user@example.tld"
+    assert ctx.request_id == "req-456"
+    assert ctx.api_version == "v57.0"
+    assert ctx.namespace == "ns"
+    assert ctx.access_token is None  # Should be None when missing
+    assert ctx.data_api.access_token is None  # DataAPI should also have None access_token


### PR DESCRIPTION
Fixes scenarios where valid requests may not include accessToken in the x-client-context header payload.

# Pull Request

## Summary
<!--
Briefly explain the purpose of this PR.
What functionality or bug does it address?
Reference any related issues with "Fixes #123" or "Closes #456".
-->
Make access_token optional and prevent KeyError when accessToken is missing from request context. 

Fixes #
---
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002K1o6vYAB/view

## What Changed

<!--
Describe the key changes in this PR.
If it's a bug fix, describe what was broken and how it's fixed.
If it's a feature, explain how it works and any limitations.
-->

accessToken was expected in the x-client-context header, in all cases even though there are valid scenarios where it may not exist.

- Make access_token optional (str | None) in ClientContext and DataAPI
- Use .get() instead of [] for accessToken extraction to prevent KeyError
- Update DataAPI._default_headers() to conditionally include Authorization header
- Add test case for missing accessToken scenario
- Update documentation to reflect optional access_token type

Fixes scenarios where valid requests may not include accessToken in the
x-client-context header payload.

---

## Checklist


- [x] I’ve added or updated unit tests where necessary
- [x] I’ve added or updated documentation
- [x] I've run `pdoc3` to generate the documentation
- [x] I’ve manually tested the functionality in this PR
- [x] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->
```
uv run pytest
```