### PR TITLE
Set `GUSINFO` team and product tag in `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Heroku EDIT,Heroku AppLink
 # Owned by the Heroku EDIT Team
 * @heroku/edit-team


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` uses the placeholder `Open Source,Open Source Workflow` rather than a real team/product tag. This change sets it to `Heroku EDIT,Heroku AppLink`.

This correction was suggested by Claude Code, based on the GitHub owner team (`@heroku/edit-team`) and the active `Heroku AppLink` product tag it owns. The reviewer should confirm the new product tag is correct and the most appropriate one for this component.

GUS-W-23525396.