### PR TITLE
Cap aiohttp<3.14 in test deps for aioresponses compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ test = [
     "ruff>=0.1.0",
     "coverage>=7.0.0",
     "aioresponses>=0.7.8",
+    # aioresponses#289: aiohttp 3.14 made ClientResponse's stream_writer kwarg
+    # required, which aioresponses does not pass. Cap until upstream fixes it.
+    "aiohttp<3.14",
     "fastapi>=0.115.0",
     "uvicorn>=0.34.0",
     "httpx>=0.28.1",


### PR DESCRIPTION
## Problem

CI was failing across the entire matrix with 23 identical errors:

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
  aioresponses/core.py: TypeError
```

aiohttp 3.14 made `ClientResponse.__init__`'s `stream_writer` a required keyword-only argument, which `aioresponses` does not pass — breaking every `aioresponses`-backed test. Because test deps are unpinned, CI picked up aiohttp 3.14.2 and `aioresponses` 0.7.9 (latest, still broken). Tracked upstream in [aioresponses#289](https://github.com/pnuckowski/aioresponses/issues/289).

## Fix

Cap `aiohttp<3.14` in the **test extra only**. The runtime dependency (`aiohttp>=3.11.12`) is unchanged, so SDK consumers can still use aiohttp 3.14 — only the test mock is affected. Remove the cap once aioresponses ships a fix.